### PR TITLE
Added PaperVision Project to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Curators: Christopher, John and Moritz from [React Flow](https://reactflow.dev) 
 - [Rapidcanvas](https://rapidcanvas.ai/) - Data science platform
 - [Slang](https://bitspark.de/slang/) - Data processing tool
 - [Y42](https://www.y42.com/) - Data pipeline tool
+- [PaperVision](https://github.com/deltacv/PaperVision) - Create custom OpenCV algorithms [OSS]
 - [Orange Data Mining](https://orangedatamining.com/) - Data mining and processing tool [OSS]
 
 ### 3D & Visuals


### PR DESCRIPTION
https://github.com/deltacv/PaperVision - Create your custom OpenCV algorithms using a user-friendly node editor interface, inspired by Blender and Unreal Engine blueprints! Quickly prototype your vision using live previews as you edit.